### PR TITLE
bug fix for not allowing querystring parameters

### DIFF
--- a/src/Simgroep/Oauth1Service/Service.php
+++ b/src/Simgroep/Oauth1Service/Service.php
@@ -145,7 +145,7 @@ class Service
     protected function getBaseUrl()
     {
         $parts = parse_url($this->request->getRequestUri());
-        return sprintf('%s%s%s', $parts['scheme'] . $parts['host'], $parts['path']);
+        return sprintf('%s://%s%s', $parts['scheme'] , $parts['host'], $parts['path']);
     }
 }
 


### PR DESCRIPTION
Changed method to string query string from url the right way
